### PR TITLE
feat: add sprig integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    alias(libs.plugins.kotlin.android) apply false
 }
 
 apply from: rootProject.file('gradle/promote.gradle')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,27 @@
 [versions]
 agp = "8.6.1"
+core = "[1.12,2.0)"
 junit = "4.13.2"
 appcompat = "1.7.0"
 material = "1.12.0"
+userleapAndroidSdk = "2.16.1"
+activity = "1.9.2"
+constraintlayout = "2.1.4"
+kotlin = "1.9.25"
+coreKtx = "1.13.1"
 
 [libraries]
+rudderstack-core = { module = "com.rudderstack.android.sdk:core", version.ref = "core" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+userleap-android-sdk = { module = "com.userleap:userleap-android-sdk", version.ref = "userleapAndroidSdk" }
+activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -1,10 +1,20 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
+
+Properties properties = new Properties()
+if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
+    properties.load(project.rootProject.file("sample-kotlin/local.properties").newDataInputStream())
 }
 
 android {
     namespace 'com.rudderstack.android.integration.sprig'
     compileSdk 34
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId "com.rudderstack.android.integration.sprig"
@@ -14,6 +24,9 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "DATA_PLANE_URL", properties.getProperty('dataplaneUrl', "\"https://hosted.rudderlabs.com\""))
+        buildConfigField("String", "CONTROL_PLANE_URL", properties.getProperty('controlplaneUrl', "\"https://api.rudderstack.com\""))
+        buildConfigField("String", "WRITE_KEY", properties.getProperty('writeKey', "\"\""))
     }
 
     buildTypes {
@@ -26,10 +39,19 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {
 
     implementation libs.appcompat
     implementation libs.material
+    implementation libs.activity
+    implementation libs.constraintlayout
+    implementation libs.core.ktx
+
+    implementation libs.rudderstack.core
+    implementation project(':sprig')
 }

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -2,8 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
+        android:name=".MainApplication"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
@@ -11,6 +15,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Rudderintegrationsprigandroid"
-        tools:targetApi="31" />
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
@@ -11,7 +11,6 @@ class MainActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        SprigIntegrationFactory.FACTORY.setFragmentActivity(this@MainActivity)
 
         findViewById<Button>(R.id.identify_button).setOnClickListener {
             MainApplication.rudderClient.identify(
@@ -42,6 +41,11 @@ class MainActivity: AppCompatActivity() {
         findViewById<Button>(R.id.logout_button).setOnClickListener {
             MainApplication.rudderClient.reset(false)
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        SprigIntegrationFactory.FACTORY.setFragmentActivity(this@MainActivity)
     }
 
     override fun onDestroy() {

--- a/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        SprigIntegrationFactory.FACTORY.setCurrentFragmentActivity(this@MainActivity)
+        SprigIntegrationFactory.FACTORY.setFragmentActivity(this@MainActivity)
 
         findViewById<Button>(R.id.identify_button).setOnClickListener {
             MainApplication.rudderClient.identify(
@@ -42,5 +42,10 @@ class MainActivity: AppCompatActivity() {
         findViewById<Button>(R.id.logout_button).setOnClickListener {
             MainApplication.rudderClient.reset(false)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        SprigIntegrationFactory.FACTORY.setFragmentActivity(null)
     }
 }

--- a/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
@@ -1,0 +1,42 @@
+package com.rudderstack.android.integration.sprig;
+
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import com.rudderstack.android.sdk.core.RudderProperty
+import com.rudderstack.android.sdk.core.RudderTraits
+
+class MainActivity: AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        SprigIntegrationFactory.FACTORY.setCurrentFragmentActivity(this@MainActivity)
+
+        findViewById<Button>(R.id.identify_button).setOnClickListener {
+            MainApplication.rudderClient.identify(
+                "test_user_id",
+                RudderTraits()
+                    .putEmail("test@gmail.com")
+                    .put("v1", 1)
+                    .put("v2", "2"),
+                null
+            )
+        }
+
+        findViewById<Button>(R.id.track_button).setOnClickListener {
+            MainApplication.rudderClient.track(
+                "test_event"
+            )
+        }
+
+        findViewById<Button>(R.id.track_properties_button).setOnClickListener {
+            MainApplication.rudderClient.track(
+                "test_event_with_properties",
+                RudderProperty()
+                    .putValue("key_1", "value_1")
+                    .putValue("key_2", "value_2")
+            )
+        }
+    }
+}

--- a/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainActivity.kt
@@ -38,5 +38,9 @@ class MainActivity: AppCompatActivity() {
                     .putValue("key_2", "value_2")
             )
         }
+
+        findViewById<Button>(R.id.logout_button).setOnClickListener {
+            MainApplication.rudderClient.reset(false)
+        }
     }
 }

--- a/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainApplication.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/integration/sprig/MainApplication.kt
@@ -1,0 +1,28 @@
+package com.rudderstack.android.integration.sprig
+
+import android.app.Application
+import com.rudderstack.android.sdk.core.RudderClient
+import com.rudderstack.android.sdk.core.RudderConfig
+import com.rudderstack.android.sdk.core.RudderLogger
+
+class MainApplication: Application() {
+    companion object {
+        lateinit var rudderClient: RudderClient
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        rudderClient = RudderClient.getInstance(
+            this,
+            BuildConfig.WRITE_KEY,
+            RudderConfig.Builder()
+                .withDataPlaneUrl(BuildConfig.DATA_PLANE_URL)
+                .withLogLevel(RudderLogger.RudderLogLevel.VERBOSE)
+                .withFactory(SprigIntegrationFactory.FACTORY)
+                .withTrackLifecycleEvents(false)
+                .withRecordScreenViews(false)
+                .withSleepCount(3)
+                .build()
+        )
+    }
+}

--- a/sample-kotlin/src/main/res/layout/activity_main.xml
+++ b/sample-kotlin/src/main/res/layout/activity_main.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+
+    <Button
+        android:id="@+id/identify_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="52dp"
+        android:text="identify"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/track_properties_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        android:text="Track with properties"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/identify_button" />
+
+    <Button
+        android:id="@+id/track_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        android:text="Track without properties"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/track_properties_button" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample-kotlin/src/main/res/layout/activity_main.xml
+++ b/sample-kotlin/src/main/res/layout/activity_main.xml
@@ -37,4 +37,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/track_properties_button" />
+
+    <Button
+        android:id="@+id/logout_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        android:text="Logout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/track_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sprig/build.gradle
+++ b/sprig/build.gradle
@@ -29,6 +29,11 @@ dependencies {
 
     implementation libs.appcompat
     implementation libs.material
+    // RudderStack SDK
+    compileOnly libs.rudderstack.core
+    // Sprig dependency
+    implementation libs.userleap.android.sdk
+
     testImplementation libs.junit
 }
 

--- a/sprig/proguard-rules.pro
+++ b/sprig/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.userleap.** { *; }
+-keep class sprig.** { *; }

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -1,4 +1,203 @@
 package com.rudderstack.android.integration.sprig;
 
-public class SprigIntegrationFactory {
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
+import com.rudderstack.android.sdk.core.MessageType;
+import com.rudderstack.android.sdk.core.RudderClient;
+import com.rudderstack.android.sdk.core.RudderConfig;
+import com.rudderstack.android.sdk.core.RudderIntegration;
+import com.rudderstack.android.sdk.core.RudderLogger;
+import com.rudderstack.android.sdk.core.RudderMessage;
+import com.userleap.EventPayload;
+import com.userleap.Sprig;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
+
+    // String constants
+    private static final String SPRIG_KEY = "Sprig";
+    private static final String ENVIRONMENT_ID = "ENVIRONMENT_ID";
+    private static final String EMAIL_KEY = "email";
+
+    @Nullable
+    private Sprig sprig;
+    @Nullable
+    private static FragmentActivity currentActivity;
+
+    @Override
+    public void reset() {
+        if (this.sprig != null) {
+            this.sprig.logout();
+        }
+    }
+
+    @Override
+    public void dump(RudderMessage rudderMessage) {
+        if (sprig != null) {
+            if (rudderMessage.getType() != null) {
+                switch (rudderMessage.getType()) {
+                    case MessageType.TRACK:
+                        processTrackEvent(rudderMessage);
+                        break;
+                    case MessageType.IDENTIFY:
+                        processIdentifyEvent(rudderMessage);
+                        break;
+                    default:
+                        RudderLogger.logWarn("SprigIntegrationFactory: MessageType is not valid");
+                        break;
+                }
+            }
+        } else {
+            RudderLogger.logWarn("SprigIntegrationFactory: Sprig is not initialized");
+        }
+    }
+
+    @Override
+    public Sprig getUnderlyingInstance() {
+        return sprig;
+    }
+
+    public interface SprigFactory extends Factory {
+        void setCurrentFragmentActivity(@Nullable FragmentActivity activity);
+    }
+
+    public static final SprigFactory FACTORY = new SprigFactory() {
+        @Override
+        public RudderIntegration<?> create(Object config, RudderClient rudderClient, RudderConfig rudderConfig) {
+            return new SprigIntegrationFactory(config);
+        }
+
+        @Override
+        public String key() {
+            return SPRIG_KEY;
+        }
+
+        @Override
+        public void setCurrentFragmentActivity(@Nullable FragmentActivity activity) {
+            currentActivity = activity;
+        }
+    };
+
+    private SprigIntegrationFactory(Object config) {
+        String environmentId = "";
+        Map<String, Object> destinationConfig = (Map<String, Object>) config;
+        if (destinationConfig == null) {
+            RudderLogger.logError("Invalid configuration. Aborting Sprig initialization.");
+        } else if (RudderClient.getApplication() == null) {
+            RudderLogger.logError("RudderClient is not initialized correctly. Application is null. Aborting Sprig initialization.");
+        } else {
+            if (destinationConfig.containsKey(ENVIRONMENT_ID)) {
+                environmentId = (String) destinationConfig.get(ENVIRONMENT_ID);
+            }
+            if (TextUtils.isEmpty(environmentId)) {
+                RudderLogger.logError("Invalid api key. Aborting Sprig initialization.");
+                return;
+            }
+
+            this.sprig = Sprig.INSTANCE;
+            this.sprig.configure(RudderClient.getApplication().getApplicationContext(), environmentId);
+
+            RudderClient.getApplication().registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+
+                @Override
+                public void onActivityCreated(@NonNull Activity activity, @androidx.annotation.Nullable Bundle bundle) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivityStarted(@NonNull Activity activity) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivityResumed(@NonNull Activity activity) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivityPaused(@NonNull Activity activity) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivityStopped(@NonNull Activity activity) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle bundle) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onActivityDestroyed(@NonNull Activity activity) {
+                    if (activity == currentActivity) {
+                        currentActivity = null;
+                    }
+                }
+            });
+        }
+    }
+
+    private void processTrackEvent(RudderMessage message) {
+        if (this.sprig == null) {
+            return;
+        }
+        String eventName = message.getEventName();
+        if (eventName == null) {
+            return;
+        }
+        Map<String, Object> properties = message.getProperties();
+
+        EventPayload payload = new EventPayload(eventName, null, null, properties, null, null);
+
+        if (currentActivity == null) {
+            this.sprig.track(payload);
+        } else {
+            this.sprig.trackAndPresent(payload, currentActivity);
+        }
+    }
+
+    private void processIdentifyEvent(RudderMessage message) {
+        if (this.sprig == null) {
+            return;
+        }
+        String userId = message.getUserId();
+        if (userId != null) {
+            this.sprig.setUserIdentifier(userId);
+        }
+
+        Map<String, Object> traits = message.getTraits();
+
+        if (traits != null) {
+            if (traits.containsKey(EMAIL_KEY)) {
+                String email = (String) traits.get(EMAIL_KEY);
+                if (email != null) {
+                    this.sprig.setEmailAddress(email);
+                }
+            }
+            for (Map.Entry<String, Object> entry : traits.entrySet()) {
+                if (!Objects.equals(entry.getKey(), EMAIL_KEY)) {
+                    if (entry.getValue() instanceof String) {
+                        this.sprig.setVisitorAttribute(entry.getKey(), (String) entry.getValue());
+                    }
+                    if (entry.getValue() instanceof Integer) {
+                        this.sprig.setVisitorAttribute(entry.getKey(), (Integer) entry.getValue());
+                    }
+                    if (entry.getValue() instanceof Boolean) {
+                        this.sprig.setVisitorAttribute(entry.getKey(), (Boolean) entry.getValue());
+                    }
+                }
+            }
+        }
+    }
 }

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -141,6 +141,7 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
 
                 @Override
                 public void onActivityDestroyed(@NonNull Activity activity) {
+                    // clearing the activity instance on onDestroy
                     if (activity == currentActivity) {
                         currentActivity = null;
                     }
@@ -179,22 +180,26 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
 
         Map<String, Object> traits = message.getTraits();
 
-        if (traits != null) {
-            if (traits.containsKey(EMAIL_KEY)) {
-                String email = (String) traits.get(EMAIL_KEY);
+        processSprigAttributes(traits);
+    }
+
+    private void processSprigAttributes(Map<String, Object> attributes) {
+        if (attributes != null) {
+            if (attributes.containsKey(EMAIL_KEY)) {
+                String email = (String) attributes.get(EMAIL_KEY);
                 if (email != null) {
                     this.sprig.setEmailAddress(email);
                 }
             }
-            for (Map.Entry<String, Object> entry : traits.entrySet()) {
+            for (Map.Entry<String, Object> entry : attributes.entrySet()) {
                 if (Objects.equals(entry.getKey(), EMAIL_KEY)) {
                     continue;
                 }
                 if (entry.getKey().length() < 256 && !entry.getKey().startsWith("!")) {
                     if (entry.getValue() instanceof String) {
                         this.sprig.setVisitorAttribute(entry.getKey(), (String) entry.getValue());
-                    } else if (entry.getValue() instanceof Integer) {
-                        this.sprig.setVisitorAttribute(entry.getKey(), (Integer) entry.getValue());
+                    } else if (entry.getValue() instanceof Number) {
+                        this.sprig.setVisitorAttribute(entry.getKey(), getInt(entry.getValue()));
                     } else if (entry.getValue() instanceof Boolean) {
                         this.sprig.setVisitorAttribute(entry.getKey(), (Boolean) entry.getValue());
                     } else {
@@ -205,5 +210,15 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
                 }
             }
         }
+    }
+
+    private Integer getInt(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return 0;
     }
 }

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -68,7 +68,7 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
     }
 
     public interface SprigFactory extends Factory {
-        void setCurrentFragmentActivity(@Nullable FragmentActivity activity);
+        void setFragmentActivity(@Nullable FragmentActivity activity);
     }
 
     public static final SprigFactory FACTORY = new SprigFactory() {
@@ -83,7 +83,7 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
         }
 
         @Override
-        public void setCurrentFragmentActivity(@Nullable FragmentActivity activity) {
+        public void setFragmentActivity(@Nullable FragmentActivity activity) {
             currentActivity = activity;
         }
     };

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -18,6 +18,7 @@ import com.rudderstack.android.sdk.core.RudderMessage;
 import com.userleap.EventPayload;
 import com.userleap.Sprig;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -186,16 +187,21 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
                 }
             }
             for (Map.Entry<String, Object> entry : traits.entrySet()) {
-                if (!Objects.equals(entry.getKey(), EMAIL_KEY)) {
+                if (Objects.equals(entry.getKey(), EMAIL_KEY)) {
+                    continue;
+                }
+                if (entry.getKey().length() < 256 && !entry.getKey().startsWith("!")) {
                     if (entry.getValue() instanceof String) {
                         this.sprig.setVisitorAttribute(entry.getKey(), (String) entry.getValue());
-                    }
-                    if (entry.getValue() instanceof Integer) {
+                    } else if (entry.getValue() instanceof Integer) {
                         this.sprig.setVisitorAttribute(entry.getKey(), (Integer) entry.getValue());
-                    }
-                    if (entry.getValue() instanceof Boolean) {
+                    } else if (entry.getValue() instanceof Boolean) {
                         this.sprig.setVisitorAttribute(entry.getKey(), (Boolean) entry.getValue());
+                    } else {
+                        RudderLogger.logWarn(String.format(Locale.US, "%s is not a valid property value. Only String, Bool, Double and Int are accepted as valid attributes. Ignoring property.", entry.getValue()));
                     }
+                } else {
+                    RudderLogger.logWarn(String.format(Locale.US, "%s is not a valid property name. Property names must be less than 256 characters and cannot start with a '!'. Ignoring property.", entry.getKey()));
                 }
             }
         }

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -26,7 +26,7 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
 
     // String constants
     private static final String SPRIG_KEY = "Sprig";
-    private static final String ENVIRONMENT_ID = "ENVIRONMENT_ID";
+    private static final String ENVIRONMENT_ID = "environmentId";
     private static final String EMAIL_KEY = "email";
 
     @Nullable


### PR DESCRIPTION
## Description of the change

- In this PR we added the Sprig mobile device mode integration.
- The following event types are supported: identify and track.
- RESET call is also supported.
- In order to display the survey, the FragmentActivity instance must be passed before making a track event.

ScreenShot for survey:
<img width="356" alt="Screenshot 2024-10-18 at 1 45 31 PM" src="https://github.com/user-attachments/assets/3ea2b992-7b01-4fd5-aa8f-325f51470459">

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




