### PR TITLE
feat(sprig): bump sprig sdk to [2.23.0, 3.0.0) and core sdk to [1.28.0, 2.0)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 agp = "8.6.1"
-core = "[1.12,2.0)"
+core = "[1.28.0,2.0)"
 junit = "4.13.2"
 appcompat = "1.7.0"
 material = "1.12.0"
-userleapAndroidSdk = "2.16.1"
+userleapAndroidSdk = "[2.23.0,3.0.0)"
 activity = "1.9.2"
 constraintlayout = "2.1.4"
 kotlin = "1.9.25"

--- a/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
+++ b/sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java
@@ -160,7 +160,7 @@ public class SprigIntegrationFactory extends RudderIntegration<Sprig> {
         }
         Map<String, Object> properties = message.getProperties();
 
-        EventPayload payload = new EventPayload(eventName, null, null, properties, null, null);
+        EventPayload payload = new EventPayload(eventName, null, null, properties, null, null, null);
 
         if (currentActivity == null) {
             this.sprig.track(payload);


### PR DESCRIPTION
**Fixes** [SDK-4753](https://linear.app/rudderstack/issue/SDK-4753)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Description

Updates the integration's dependency declarations to widen support for newer Sprig and RudderStack core SDKs:

- `com.userleap:userleap-android-sdk`: pinned `2.16.1` → range `[2.23.0, 3.0.0)`.
- `com.rudderstack.android.sdk:core`: range `[1.12, 2.0)` → `[1.28.0, 2.0)` (raises the floor to the latest available 1.x release).

A small source-level adaptation was required: Sprig 2.23+ added a 7th parameter to the `EventPayload` constructor (a `Function1<SurveyState, Unit>` callback). The integration's `processTrackEvent` call has been updated to pass `null` for the new parameter, preserving prior behavior.

## Implementation Details

- `gradle/libs.versions.toml`
  - `core`: `[1.12,2.0)` → `[1.28.0,2.0)`
  - `userleapAndroidSdk`: `2.16.1` → `[2.23.0,3.0.0)`
- `sprig/src/main/java/com/rudderstack/android/integration/sprig/SprigIntegrationFactory.java`
  - `EventPayload(...)` updated from 6 args to 7 args (trailing `null` for the new survey-state callback).

## Checklist:
- [x] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## How to test?

1. Build the `:sprig` module: `./gradlew :sprig:assembleRelease` — should succeed.
2. Confirm resolved versions: `./gradlew :sprig:dependencies --configuration releaseCompileClasspath` — expect `core` resolved to `1.28.0` and `userleap-android-sdk` resolved to the latest available within `[2.23.0, 3.0.0)` (currently `2.24.0`).
3. Run the `sample-kotlin` app and verify identify/track events flow into Sprig and surveys present as expected.

## Breaking Changes

None for consumers of this integration. The downstream `com.userleap:userleap-android-sdk` constructor change is internal to this integration and has been adapted.
