### PR TITLE
chore(ci): migrate publish endpoints from legacy ossrh to sonatype central portal

### DIFF
--- a/gradle/promote.gradle
+++ b/gradle/promote.gradle
@@ -56,8 +56,8 @@ nexusPublishing {
             username = System.getenv('NEXUS_USERNAME')
             password = System.getenv('NEXUS_PASSWORD')
 
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
**Fixes** [SDK-4753](https://linear.app/rudderstack/issue/SDK-4753)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Description

Migrates Maven publishing endpoints from the legacy OSSRH host (`s01.oss.sonatype.org`) to the Sonatype Central Portal. The legacy hosts were sunset by Sonatype in 2025 and now reject uploads with `HTTP 405 Not Allowed`, which has been causing the `Snapshot` GitHub Actions job to fail on every PR (and on `main`) since April 2026.

The Central Portal endpoints used here mirror those already in use by the working `rudder-integration-firebase-android` publish pipeline.

## Implementation Details

`gradle/promote.gradle` — `nexusPublishing { repositories { sonatype { ... } } }`:

- `nexusUrl`: `https://s01.oss.sonatype.org/service/local/` → `https://ossrh-staging-api.central.sonatype.com/service/local/`
- `snapshotRepositoryUrl`: `https://s01.oss.sonatype.org/content/repositories/snapshots/` → `https://central.sonatype.com/repository/maven-snapshots/`

No code, dependency, plugin version, or workflow changes — the existing Snapshot workflow already invokes `./gradlew publishToSonatype` with the same credentials (`NEXUS_USERNAME` / `NEXUS_PASSWORD` / signing secrets), which the Central Portal accepts.

## Checklist:
- [x] Version upgraded (project, README, gradle, podspec etc) — N/A, no version bump required
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## How to test?

1. CI: the `Snapshot` job on this PR should now succeed (it has been failing with `HTTP 405` on every prior PR in 2026).
2. Post-merge: trigger a snapshot publish on `main` and verify the artifact appears at `https://central.sonatype.com/repository/maven-snapshots/com/rudderstack/android/integration/sprig/`.
3. Release publish path uses the same `nexusUrl` for staging upload — confirm the next release flow still creates a staging repository and closes/releases successfully.

## Breaking Changes

None at the consumer level. Internal CI/publish-infrastructure change only.

## Additional Context

- Same change pattern as `rudder-integration-firebase-android/gradle/promote.gradle` (already migrated and passing snapshot CI).
- Other RudderStack Android integration repos that still point at `s01.oss.sonatype.org` will need the same migration — out of scope for this PR.
