### PR TITLE
ci(release): align draft_new_release branch creation with firebase pattern

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -43,13 +43,11 @@ jobs:
       # Calculate the next release version based on conventional semantic release
       - name: Calculate release version and create branch
         id: create-release
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
 
-          git fetch origin main
+          git fetch origin main --depth=1
           git merge origin/main
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
 
@@ -65,20 +63,11 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
+          git checkout -b "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
-
-      - name: Create release branch via GitHub API
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          BASE_SHA=$(git rev-parse origin/main)
-          gh api repos/${{ github.repository }}/git/refs \
-            --method POST \
-            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
-            -f sha="$BASE_SHA"
 
       - name: Generate changelog and bump version
         run: |


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Description

Aligns `draft_new_release.yml` with the working pattern in [rudder-integration-firebase-android](https://github.com/rudderlabs/rudder-integration-firebase-android/blob/master/.github/workflows/draft_new_release.yml). Fixes the shallow-fetch bug surfaced during the 1.1.0 release and unlocks the long-term integration-branch release flow.

## Background

While cutting 1.1.0, the workflow initially computed a patch bump (`1.0.1`) with an empty CHANGELOG instead of the expected `1.1.0`. Root cause: `git fetch origin main --depth=1` applied a shallow boundary at `origin/main`, and because the source branch was a copy of `main`, the same SHA was the local HEAD — so the shallow boundary retroactively hid the `feat:` commit on the merged branch from `standard-version`.

A short-term fix (`fcad0ba`) removed `--depth=1`. This PR replaces that ad-hoc patch with the structural fix used by the firebase integration repo.

## What changes

1. **Replace API-based release branch creation with `git checkout -b`.** The release branch now inherits the source branch's commits, matching firebase. Removes the separate `Create release branch via GitHub API` step.
2. **Restore `--depth=1` on the `origin/main` fetch.** Safe again because the source branch will diverge from main under the integration-branch pattern (see below).

Net diff: +2 / -13 lines.

## Process implication

This workflow assumes the **integration-branch release pattern** going forward (same as firebase):

- Create a long-lived `feat/release-X.Y.Z` branch from `main` at the start of a release cycle.
- Feature PRs target `feat/release-X.Y.Z` instead of `main`.
- When the release is ready, run *Draft new release* from `feat/release-X.Y.Z`. The workflow creates `release/X.Y.Z` carrying all those commits, plus the auto-generated CHANGELOG and version bump.
- Merge the auto-created release PR into `main`.

## How to test

1. Create a `feat/release-test-X.Y.Z` branch from `main` and merge a feature PR into it.
2. Trigger *Draft new release* from `feat/release-test-X.Y.Z`.
3. Verify the auto-created `release/X.Y.Z` PR contains both the feature commit(s) and the `chore(release): vX.Y.Z` version bump.
4. Confirm the version computed by `standard-version` reflects the feature's bump level (`feat:` → minor, `fix:` → patch).

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Breaking Changes

None for consumers. Internal release-process change: feature PRs should target a `feat/release-X.Y.Z` integration branch rather than `main` directly, going forward.